### PR TITLE
Delete unused args

### DIFF
--- a/chat_assistant/training/train.py
+++ b/chat_assistant/training/train.py
@@ -63,10 +63,6 @@ class ScriptArguments:
         default="timdettmers/openassistant-guanaco",
         metadata={"help": "The preference dataset to use."},
     )
-    use_4bit: Optional[bool] = field(
-        default=True,
-        metadata={"help": "Activate 4bit precision base model loading"},
-    )
     use_nested_quant: Optional[bool] = field(
         default=False,
         metadata={"help": "Activate nested quantization for 4bit base models"},


### PR DESCRIPTION
1. The use_4bit args is ununsed and duplicated with use_4bit_quantization.
2. use_4bit is default to True and use_4bit_quantization is default to False, which make users confusing.