### PR TITLE
remove the need to shard the model post saving when using FSDP

### DIFF
--- a/chat_assistant/training/train.py
+++ b/chat_assistant/training/train.py
@@ -37,7 +37,9 @@ class ScriptArguments:
     These arguments vary depending on how many GPUs you have, what their capacity and features are, and what size model you want to train.
     """
 
-    local_rank: Optional[int] = field(default=-1, metadata={"help": "Used for multi-gpu"})
+    local_rank: Optional[int] = field(
+        default=-1, metadata={"help": "Used for multi-gpu"}
+    )
 
     per_device_train_batch_size: Optional[int] = field(default=4)
     per_device_eval_batch_size: Optional[int] = field(default=1)
@@ -50,7 +52,9 @@ class ScriptArguments:
     lora_r: Optional[int] = field(default=64)
     lora_target_modules: Optional[str] = field(
         default="q_proj,k_proj,v_proj,o_proj,down_proj,up_proj,gate_proj",
-        metadata={"help": "comma separated list of target modules to apply LoRA layers to"},
+        metadata={
+            "help": "comma separated list of target modules to apply LoRA layers to"
+        },
     )
     max_seq_length: Optional[int] = field(default=512)
     model_name: Optional[str] = field(
@@ -101,14 +105,26 @@ class ScriptArguments:
     )
     lr_scheduler_type: str = field(
         default="constant",
-        metadata={"help": "Learning rate schedule. Constant a bit better than cosine, and has advantage for analysis"},
+        metadata={
+            "help": "Learning rate schedule. Constant a bit better than cosine, and has advantage for analysis"
+        },
     )
-    max_steps: int = field(default=10000, metadata={"help": "How many optimizer update steps to take"})
-    warmup_ratio: float = field(default=0.03, metadata={"help": "Fraction of steps to do a warmup for"})
-    save_steps: int = field(default=10, metadata={"help": "Save checkpoint every X updates steps."})
+    max_steps: int = field(
+        default=10000, metadata={"help": "How many optimizer update steps to take"}
+    )
+    warmup_ratio: float = field(
+        default=0.03, metadata={"help": "Fraction of steps to do a warmup for"}
+    )
+    save_steps: int = field(
+        default=10, metadata={"help": "Save checkpoint every X updates steps."}
+    )
     eval_steps: int = field(default=10, metadata={"help": "Eval model every X steps."})
-    logging_steps: int = field(default=10, metadata={"help": "Log every X updates steps."})
-    output_dir: str = field(default="results", metadata={"help": "Where to store the final model."})
+    logging_steps: int = field(
+        default=10, metadata={"help": "Log every X updates steps."}
+    )
+    output_dir: str = field(
+        default="results", metadata={"help": "Where to store the final model."}
+    )
     use_flash_attn: Optional[bool] = field(
         default=False,
         metadata={"help": "Enables Flash attention for training."},
@@ -129,22 +145,29 @@ class ScriptArguments:
         default=False,
         metadata={"help": "Enables Gradient Checkpointing."},
     )
-    dataset_text_field: str = field(default="text", metadata={"help": "Dataset field to use as input text."})
+    dataset_text_field: str = field(
+        default="text", metadata={"help": "Dataset field to use as input text."}
+    )
     push_to_hub: Optional[bool] = field(
         default=False,
         metadata={"help": "If True, pushes the model to the HF Hub"},
     )
-    num_workers: int = field(default=4, metadata={"help": "Number of dataset workers to use."})
+    num_workers: int = field(
+        default=4, metadata={"help": "Number of dataset workers to use."}
+    )
     debug: Optional[bool] = field(
         default=False,
-        metadata={"help": "If True, tests things like proper saving/loading/logging of model"},
+        metadata={
+            "help": "If True, tests things like proper saving/loading/logging of model"
+        },
     )
 
 
 def main(args):
     # training arguments
     is_deepspeed_peft_enabled = (
-        os.environ.get("ACCELERATE_USE_DEEPSPEED", "False").lower() == "true" and args.use_peft_lora
+        os.environ.get("ACCELERATE_USE_DEEPSPEED", "False").lower() == "true"
+        and args.use_peft_lora
     )
     save_strategy = "no" if is_deepspeed_peft_enabled else "steps"
     training_arguments = TrainingArguments(
@@ -178,13 +201,20 @@ def main(args):
     train_dataset, eval_dataset = create_datasets(tokenizer, args)
 
     # trainer
-    trainer = Trainer(model=model, args=training_arguments, train_dataset=train_dataset, eval_dataset=eval_dataset)
+    trainer = Trainer(
+        model=model,
+        args=training_arguments,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+    )
     trainer.accelerator.print(f"{trainer.model}")
     if args.use_peft_lora:
         trainer.model.print_trainable_parameters()
 
     if is_deepspeed_peft_enabled:
-        trainer.add_callback(SaveDeepSpeedPeftModelCallback(trainer, save_steps=args.save_steps))
+        trainer.add_callback(
+            SaveDeepSpeedPeftModelCallback(trainer, save_steps=args.save_steps)
+        )
 
     if args.use_peft_lora:
         peft_module_casting_to_bf16(trainer.model, args)
@@ -211,22 +241,9 @@ def main(args):
         else:
             tokenizer.save_pretrained(args.output_dir)
             trainer.save_model(args.output_dir)
-
-    # Save everything else on main process
-    if trainer.args.process_index == 0:
-        print("Sharding model if >10GB...")
-        # FSDP/DeepSpeed save the model as a single `pytorch_model.bin` file, so we need to shard it.
-        # We run this in a subprocess to avoid interference from the accelerators.
-        subprocess.run(
-            [
-                "python",
-                "shard_checkpoint.py",
-                f"--output_dir={args.output_dir}",
-            ],
-            check=True,
-        )
-        if "training_args.bin" in os.listdir(args.output_dir):
-            os.remove(os.path.join(args.output_dir, "training_args.bin"))
+    trainer.accelerator.print(f"Model saved to {args.output_dir}")
+    if args.push_to_hub:
+        trainer.model.push_to_hub(args.output_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What does this PR do?
1. Based on the PRs https://github.com/huggingface/accelerate/pull/2177 and https://github.com/huggingface/transformers/pull/27652, updating the code related to FSDP model saving. Now, DeepSpeed/FSDP save the model weights in the transformers sharded safetensors format by default. Yay!