### PR TITLE
Fix wrong fim token ids for deepseek-coder

### DIFF
--- a/personal_copilot/training/fim.py
+++ b/personal_copilot/training/fim.py
@@ -31,9 +31,9 @@ def get_fim_token_ids(tokenizer):
     elif "deepseek-coder" in tokenizer.name_or_path:
         return (
             tokenizer.bos_token_id,
-            tokenizer.encode("<｜fim▁end｜>", add_special_tokens=False)[0],
-            tokenizer.encode("<｜fim▁begin｜>", add_special_tokens=False)[0],
             tokenizer.encode("<｜fim▁hole｜>", add_special_tokens=False)[0],
+            tokenizer.encode("<｜fim▁begin｜>", add_special_tokens=False)[0],
+            tokenizer.encode("<｜fim▁end｜>", add_special_tokens=False)[0],
             tokenizer.encode("<pad>", add_special_tokens=False)[0],
         )
     elif "stable-code" in tokenizer.name_or_path:


### PR DESCRIPTION
According https://arxiv.org/pdf/2401.14196.pdf, the <｜fim_hole｜> is suffix token